### PR TITLE
Update check_graphite_data

### DIFF
--- a/graphite_data/check_graphite_data
+++ b/graphite_data/check_graphite_data
@@ -46,7 +46,7 @@ def check_graphite_data_desc(params):
     return "Graphite %s" % params[0]
 
 active_check_info['graphite'] = {
-    "command_line"        : '$USER1$/check_graphite_data $ARG1$',
+    "command_line"        : '$USER2$/check_graphite_data $ARG1$',
     "argument_function"   : check_graphite_data_arguments,
     "service_description" : check_graphite_data_desc,
     "has_perfdata"        : True,


### PR DESCRIPTION
Hello, 

the command_line should use $USER2$ instead of $USER1$, otherwise Check_MK will look at the wrong directory for the check_graphite_data plugin.

Kind regards, Dennis
